### PR TITLE
fix --test for srv record

### DIFF
--- a/lib/roadworker/dsl-tester.rb
+++ b/lib/roadworker/dsl-tester.rb
@@ -82,11 +82,11 @@ module Roadworker
             expected_value = (record.resource_records || []).map {|i| i[:value].strip }.sort
             expected_ttl = fetch_dns_name(record.dns_name) ? 60 : record.ttl
 
-            actual_value = response.answer.map {|i| (%w(TXT SPF).include?(type) ? i.txt : i.value).strip }.sort
+            actual_value = response.answer.map {|i| (%w(TXT SPF).include?(type) ? i.txt : type == 'SRV' ? [i.priority, i.weight, i.port, i.host].join(' ') : i.value).strip }.sort
             actual_ttls = response.answer.map {|i| i.ttl }
 
             case type
-            when 'NS', 'PTR', 'MX', 'CNAME'
+            when 'NS', 'PTR', 'MX', 'CNAME', 'SRV'
               expected_value = expected_value.map {|i| i.downcase.sub(/\.\Z/, '') }
               actual_value = actual_value.map {|i| i.downcase.sub(/\.\Z/, '') }
             when 'TXT', 'SPF'


### PR DESCRIPTION
fix `roadwork --test` for srv record.

error sample Routefile.

```
  rrset "_imaps._tcp.netblue.jp.", "SRV" do
    ttl 86400
    resource_records(
      "10 5 993 netblue.jp"
    )
  end
```

see error message below.

```
$ roadwork -t --debug
Check DNS: _imaps._tcp.netblue.jp. SRV
/Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:85:in `block (3 levels) in test': undefined method `strip' for nil:NilClass (NoMethodError)
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:85:in `map'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:85:in `block (2 levels) in test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:81:in `each'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:81:in `any?'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:81:in `block in test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:225:in `call'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:225:in `block in test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:224:in `each'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:224:in `test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl-tester.rb:38:in `test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/dsl.rb:23:in `test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/lib/roadworker/client.rb:55:in `test'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/lib/ruby/gems/2.1.0/gems/roadworker-0.4.8/bin/roadwork:132:in `<top (required)>'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/bin/roadwork:23:in `load'
        from /Users/d6rkaiz/.rbenv/versions/2.1.2/bin/roadwork:23:in `<main>'
```
