### PR TITLE
add ostruct as a explicit dependency

### DIFF
--- a/roadworker.gemspec
+++ b/roadworker.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "systemu"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
+  spec.add_dependency "ostruct"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"


### PR DESCRIPTION
it'll be removed from stdlib soon