### PR TITLE
check AAAA record identicalness using IPAddr

### DIFF
--- a/lib/roadworker.rb
+++ b/lib/roadworker.rb
@@ -7,6 +7,7 @@ require 'uri'
 require 'uuid'
 require 'diffy'
 require 'hashie'
+require 'ipaddr'
 
 require 'roadworker/string_helper'
 require 'roadworker/struct-ext'

--- a/lib/roadworker/route53-wrapper.rb
+++ b/lib/roadworker/route53-wrapper.rb
@@ -214,6 +214,10 @@ module Roadworker
 
                 actual[0].sub!(/\Adualstack\./i, '')
               end
+            when :resource_records
+              if self.type == 'AAAA'
+                return expected.map { |v| IPAddr.new(v.value, Socket::AF_INET6) } == actual.map { |v| IPAddr.new(v.value, Socket::AF_INET6) }
+              end
             end
 
             (expected == actual)

--- a/roadworker.gemspec
+++ b/roadworker.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "systemu"
   spec.add_dependency "diffy"
   spec.add_dependency "hashie"
+  spec.add_dependency "ipaddr"
   spec.add_development_dependency "bundler"
   spec.add_development_dependency "rake"
   spec.add_development_dependency "rspec", ">= 3.0.0"


### PR DESCRIPTION
Route 53 appears to retain the initial string representation even if client upserts with a different string representation when both represents the same address (e.g. 2001:0db8::a => 2001:db8::a, but route53 still returns 0db8 in further read API calls). Parse string representation and compare the actual addresses for difference check.