### PR TITLE
Fix health check ID error when health_checks is empty

### DIFF
--- a/lib/roadworker/dsl-converter.rb
+++ b/lib/roadworker/dsl-converter.rb
@@ -32,6 +32,8 @@ module Roadworker
                 "#{key}(\n      #{value}\n    )"
               end
             when :health_check_id
+              return if @health_checks.empty?
+
               config = HealthCheck.config_to_hash(@health_checks[value])
 
               if config[:calculated]


### PR DESCRIPTION
```
$ envchain xxx bundle exec roadwork -e -o Routefile
bundler: failed to load command: roadwork (/Users/koheisg/.rbenv/versions/3.4.2/bin/roadwork)
/Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/route53-health-check.rb:14:in 'Roadworker::HealthCheck.config_to_hash': undefined method '[]' for nil (NoMethodError)

        type = config[:type].downcase
                     ^^^^^^^
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:35:in 'block in Roadworker::DSL::Converter#output_rrset'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:25:in 'Hash#each'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:25:in 'Enumerable#map'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:25:in 'Roadworker::DSL::Converter#output_rrset'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:100:in 'block in Roadworker::DSL::Converter#output_zone'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:100:in 'Array#map'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:100:in 'Roadworker::DSL::Converter#output_zone'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:16:in 'block in Roadworker::DSL::Converter#convert'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:16:in 'Array#map'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:16:in 'Roadworker::DSL::Converter#convert'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl-converter.rb:6:i
n 'Roadworker::DSL::Converter.convert'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/dsl.rb:13:in 'Roadwo
rker::DSL.convert'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/lib/roadworker/client.rb:39:in 'Roadworker::Client#export'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/roadworker-0.6.0/bin/roadwork:140:in '<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.4.2/bin/roadwork:25:in 'Kernel#load'
        from /Users/koheisg/.rbenv/versions/3.4.2/bin/roadwork:25:in '<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:59:in 'Kernel.load'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:59:in 'Bundler::CLI::Exec#kernel_load'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli/exec.rb:23:in 'Bundler::CLI::Exec#run'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:452:in 'Bundler::CLI#exec'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/command.rb:28:in 'Bundler::Thor::Command#run'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/invocation.rb:127:in 'Bundler::Thor::Invocation#invoke_command'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor.rb:538:in 'Bundler::Thor.dispatch'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:35:in 'Bundler::CLI.dispatch'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/vendor/thor/lib/thor/base.rb:584:in 'Bundler::Thor::Base::ClassMethods#start'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/cli.rb:29:in 'Bundler::CLI.start'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:28:in 'block in <top (required)>'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/lib/bundler/friendly_errors.rb:117:in 'Bundler.with_friendly_errors'
        from /Users/koheisg/.rbenv/versions/3.4.2/lib/ruby/gems/3.4.0/gems/bundler-2.6.7/exe/bundle:20:in '<top (required)>'
        from /Users/koheisg/.rbenv/versions/3.4.2/bin/bundle:25:in 'Kernel#load'
        from /Users/koheisg/.rbenv/versions/3.4.2/bin/bundle:25:in '<main>'

```